### PR TITLE
check for opted out owners correctly

### DIFF
--- a/api/orders.ts
+++ b/api/orders.ts
@@ -366,9 +366,13 @@ const filterNonOptedInOrders = async (orders:DBOrder[]):Promise<DBOrder[]> => {
     console.error(e);
     throw e;
   }
-  const optedInOwners:string[] = ownerOptInResults.rows
-    .filter(row => row.value.assetChangeType === 'optIn')
-    .map(row => row.key.split(':')[0]); //key contains escrow address
+
+  const optedOutOwnersSet = new Set<string>(ownerOptInResults.rows
+    .filter(row => row.value.assetChangeType === 'optOut')
+    .map(row => row.key.split(':')[0]));
+
+  const optedInOwners:string[] = orders.map(order => order.ownerAddress)
+    .filter(owner => !optedOutOwnersSet.has(owner))
 
   const optedInOwnersSet = new Set<string>(optedInOwners);
 


### PR DESCRIPTION
# ℹ Overview

This fixes an issue where wallets that opted into assets before the Mainnet epoch (Feb 10 or so) are not having their orders shown in the order book.

### 📝 Related Issues

<!--- Pin any related issues -->

### 🔐 Acceptance:
<!-- Ensure the following are completed and mark the result with an [X] -->

- [ ] `yarn test` passes
