### PR TITLE
ignore earlier failed transactions before epoch 38. Don't vest reward…

### DIFF
--- a/src/rewards/distribute/vest-distribute-rewards.ts
+++ b/src/rewards/distribute/vest-distribute-rewards.ts
@@ -194,6 +194,7 @@ const getPlannedDistributions = async (input:DistributeRewardsInput): Promise<Ar
     return !allVestedRewardKeySet.has(key);
   })
   .filter(rewardsDoc => rewardsDoc.earnedRewardsFormatted >= 1)
+  .filter(rewardsDoc => rewardsDoc.epoch > 38) // Ignore earlier failed transactions
   .map(rewardsDoc => {
     const plannedSend:PlannedDistribution = {
       algodClient: input.algodClient,


### PR DESCRIPTION
…s before this epoch

# ℹ Overview

<!--- Provide an overview of the Pull Request -->

### 📝 Related Issues

<!--- Pin any related issues -->

### 🔐 Acceptance:
<!-- Ensure the following are completed and mark the result with an [X] -->

- [ ] `yarn test` passes
